### PR TITLE
Allow the used request options to be included in ResinRequestErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+- Include request options in `ResinRequestError`
+
 ## [2.4.0] - 2016-04-28
 
 - Add `ResinAmbiguousApplication` error.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Documentation
     * [.ResinKeyNotFound](#module_errors.ResinKeyNotFound)
         * [new exports.ResinKeyNotFound(key)](#new_module_errors.ResinKeyNotFound_new)
     * [.ResinRequestError](#module_errors.ResinRequestError)
-        * [new exports.ResinRequestError(body, statusCode)](#new_module_errors.ResinRequestError_new)
+        * [new exports.ResinRequestError(body, statusCode, [requestOptions])](#new_module_errors.ResinRequestError_new)
     * [.ResinNotLoggedIn](#module_errors.ResinNotLoggedIn)
 
 <a name="module_errors.ResinInvalidDeviceType"></a>
@@ -213,13 +213,14 @@ throw new errors.ResinKeyNotFound('MyKey')
 **Access:** public  
 <a name="new_module_errors.ResinRequestError_new"></a>
 
-#### new exports.ResinRequestError(body, statusCode)
+#### new exports.ResinRequestError(body, statusCode, [requestOptions])
 **Returns**: <code>Error</code> - error instance  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | body | <code>String</code> | response body |
 | statusCode | <code>Number</code> | http status code |
+| [requestOptions] | <code>Object</code> | options used to make the request |
 
 **Example**  
 ```js

--- a/build/errors.js
+++ b/build/errors.js
@@ -264,6 +264,7 @@ exports.ResinKeyNotFound = ResinKeyNotFound = (function(_super) {
  *
  * @param {String} body - response body
  * @param {Number} statusCode - http status code
+ * @param {Object} [requestOptions] - options used to make the request
  * @return {Error} error instance
  *
  * @example
@@ -273,9 +274,10 @@ exports.ResinKeyNotFound = ResinKeyNotFound = (function(_super) {
 exports.ResinRequestError = ResinRequestError = (function(_super) {
   __extends(ResinRequestError, _super);
 
-  function ResinRequestError(body, statusCode) {
+  function ResinRequestError(body, statusCode, requestOptions) {
     this.body = body;
     this.statusCode = statusCode;
+    this.requestOptions = requestOptions;
     ResinRequestError.__super__.constructor.call(this, "Request error: " + this.body);
   }
 

--- a/lib/errors.coffee
+++ b/lib/errors.coffee
@@ -171,13 +171,14 @@ exports.ResinKeyNotFound = class ResinKeyNotFound extends TypedError
 #
 # @param {String} body - response body
 # @param {Number} statusCode - http status code
+# @param {Object} [requestOptions] - options used to make the request
 # @return {Error} error instance
 #
 # @example
 # throw new errors.ResinRequestError('Unauthorized')
 ###
 exports.ResinRequestError = class ResinRequestError extends TypedError
-	constructor: (@body, @statusCode) ->
+	constructor: (@body, @statusCode, @requestOptions) ->
 		super("Request error: #{@body}")
 
 	code: 'ResinRequestError'


### PR DESCRIPTION
This is another PR as part of https://github.com/resin-io/resin-ui/issues/400 - we need to be able to do different things with failing GET and POST requests, and to retry requests after they fail, and to do that we have to have the original request options used in the thrown error.